### PR TITLE
Add build script to generate a module manifest

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -1,9 +1,27 @@
 [CmdletBinding()]
-param()
+param(
+    [string]$Version = '0.0.1'
+)
+
+if (Test-Path "$PSScriptRoot\secrets.ps1") {
+    Write-Verbose 'secrets.ps1 file found. Loading secrets...'
+    . $PSScriptRoot\secrets.ps1
+}
 
 Write-Verbose -Message 'Installing required dependencies...'
 . $PSScriptRoot\tools\install.ps1
 
-# TODO: Create a psd1 manifest with all properties properly referenced
+Copy-Item -Path "$PSScriptRoot\src\*.ps1", "$PSScriptRoot\src\*.psm1" -Destination "$PSScriptRoot\bin" -Force -Verbose
+
+New-ModuleManifest -Path $PSScriptRoot\bin\PoshOtel.psd1 -RequiredAssemblies(
+    # TODO: How to support multiple versions of the same assembly for consumers?
+    'Google.Protobuf.3.15.5\lib\netstandard2.0\Google.Protobuf.dll',
+    'Grpc.Core.2.43.0\lib\netstandard2.0\Grpc.Core.dll',
+    'Grpc.Core.Api.2.43.0\lib\netstandard2.0\Grpc.Core.Api.dll',
+    'OpenTelemetry.1.2.0-rc2\lib\netstandard2.0\OpenTelemetry.dll',
+    'OpenTelemetry.Api.1.2.0-rc2\lib\netstandard2.0\OpenTelemetry.Api.dll',
+    'OpenTelemetry.Exporter.Console.1.2.0-rc2\lib\netstandard2.0\OpenTelemetry.Exporter.Console.dll',
+    'OpenTelemetry.Exporter.OpenTelemetryProtocol.1.2.0-rc2\lib\netstandard2.0\OpenTelemetry.Exporter.OpenTelemetryProtocol.dll'
+) -RootModule 'PoshOtel.psm1' -Author 'Shayde Nofziger' -ModuleVersion $Version -Description 'An Open Telemetry Client for use in PowerShell scripts' -Guid ([Guid]::new('2CA13CCF-8751-4D25-9CBF-998727787367')) -CompanyName 'PoshOtel' -Verbose
 
 # TODO: Pester tests

--- a/src/Initialize-PoshOtel.ps1
+++ b/src/Initialize-PoshOtel.ps1
@@ -8,9 +8,6 @@ using namespace OpenTelemetry.Exporter.OpenTelemetryProtocol
 # TODO: Is Global scope necessary to maintain the instance and not let it be disposed?
 $Global:PoshOtelTracerProvider = $null
 
-$ProjectRoot = Split-Path -Path $PSScriptRoot -Parent
-$BinDirectory = Join-Path -Path $ProjectRoot -ChildPath 'bin'
-
 function InternalInitializeOtlpTracerProvider {
     [CmdletBinding()]
     param(
@@ -21,10 +18,11 @@ function InternalInitializeOtlpTracerProvider {
     )
 
     <#
-            internal const string EndpointEnvVarName = "OTEL_EXPORTER_OTLP_ENDPOINT";
-            internal const string HeadersEnvVarName = "OTEL_EXPORTER_OTLP_HEADERS";
-            internal const string TimeoutEnvVarName = "OTEL_EXPORTER_OTLP_TIMEOUT";
-            internal const string ProtocolEnvVarName = "OTEL_EXPORTER_OTLP_PROTOCOL";
+        Per the OTLP .NET documentation, these values can be configured via environment variables.
+            EndpointEnvVarName = "OTEL_EXPORTER_OTLP_ENDPOINT"
+            HeadersEnvVarName = "OTEL_EXPORTER_OTLP_HEADERS"
+            TimeoutEnvVarName = "OTEL_EXPORTER_OTLP_TIMEOUT"
+            ProtocolEnvVarName = "OTEL_EXPORTER_OTLP_PROTOCOL"
     #>
 
     $resourceBuilder = [OpenTelemetry.Resources.ResourceBuilder]::CreateDefault()
@@ -41,27 +39,6 @@ function InternalInitializeOtlpTracerProvider {
     $Global:PoshOtelTracerProvider = [TracerProviderBuilderExtensions]::Build($tracerProviderBuilder)
 }
 
-function InternalRegisterTypes {
-    [CmdletBinding()]
-    param()
-
-    # TODO: Make versioning easier
-    # Note: These are in a specific order to ensure inner dependencies are loaded before their consuming dependencies.
-    [string[]]$TypesToAdd = @(
-        "$BinDirectory\OpenTelemetry.Api.1.2.0-rc2\lib\netstandard2.0\OpenTelemetry.Api.dll",
-        "$BinDirectory\OpenTelemetry.1.2.0-rc2\lib\netstandard2.0\OpenTelemetry.dll",
-        "$BinDirectory\Google.Protobuf.3.15.5\lib\netstandard2.0\Google.Protobuf.dll",
-        "$BinDirectory\Grpc.Core.Api.2.43.0\lib\netstandard2.0\Grpc.Core.Api.dll",
-        "$BinDirectory\Grpc.Core.2.43.0\lib\netstandard2.0\Grpc.Core.dll",
-        "$BinDirectory\OpenTelemetry.Exporter.Console.1.2.0-rc2\lib\netstandard2.0\OpenTelemetry.Exporter.Console.dll",
-        "$BinDirectory\OpenTelemetry.Exporter.OpenTelemetryProtocol.1.2.0-rc2\lib\netstandard2.0\OpenTelemetry.Exporter.OpenTelemetryProtocol.dll"
-    )
-
-    foreach ($PathToType in $TypesToAdd) {
-        Add-Type -Path $PathToType
-    }
-}
-
 function Initialize-PoshOtel {
     [CmdletBinding()]
     param(
@@ -74,8 +51,4 @@ function Initialize-PoshOtel {
     InternalInitializeOtlpTracerProvider -ServiceName $ServiceName -ServiceVersion $ServiceVersion
 }
 
-InternalRegisterTypes
-
-Export-ModuleMember -Function @(
-    'Initialize-PoshOtel'
-)
+Export-ModuleMember -Function Initialize-PoshOtel

--- a/src/OtelTraceSpanOperations.ps1
+++ b/src/OtelTraceSpanOperations.ps1
@@ -12,7 +12,7 @@ function Get-OtelActivitySource {
         [string] $ServiceName
     )
 
-    return [ActivitySource]::new($ServiceName)
+    return [System.Diagnostics.ActivitySource]::new($ServiceName)
 }
 
 function New-OtelTraceSpan {
@@ -23,7 +23,7 @@ function New-OtelTraceSpan {
         [Parameter(Mandatory = $true)]
         [string] $ActivityName,
         [Parameter()]
-        [ActivityKind] $ActivityKind = [ActivityKind]::Server,
+        [System.Diagnostics.ActivityKind] $ActivityKind = [System.Diagnostics.ActivityKind]::Server,
         [Parameter()]
         [switch]$RootSpan
     )
@@ -38,7 +38,4 @@ function New-OtelTraceSpan {
     return $activity
 }
 
-Export-ModuleMember -Function @(
-    'Get-OtelActivitySource',
-    'New-OtelTraceSpan'
-)
+Export-ModuleMember -Function New-OtelTraceSpan, Get-OtelActivitySource

--- a/tools/install.ps1
+++ b/tools/install.ps1
@@ -1,4 +1,4 @@
 # Get nuget.exe
 if (-not (Test-Path -Path $PSScriptRoot\nuget.exe)) { Invoke-WebRequest -Uri 'https://dist.nuget.org/win-x86-commandline/latest/nuget.exe' -OutFile "$PSScriptRoot\nuget.exe" }
-. $PSScriptRoot\nuget.exe install $PSScriptRoot\packages.config -OutputDirectory $PSScriptRoot\..\bin
+. $PSScriptRoot\nuget.exe install $PSScriptRoot\packages.config -OutputDirectory $PSScriptRoot\..\bin\packages -ExcludeVersion
 


### PR DESCRIPTION
Makes progress towards #3 

Copies files from src to bin and generates a module manifest definition file.

Calling import-module on the psd1 succeeds and assemblies load, allowing spans to be created, started, tagged, stopped, and sent to honeycomb

TODO:
- [x] properly list out file list and tweaking to make Publish-Module successful.