### PR TITLE
Support PowerShell 7 on Windows

### DIFF
--- a/build/build.ps1
+++ b/build/build.ps1
@@ -58,13 +58,12 @@ $NewModuleManifestSplat = @{
     CompanyName = 'PoshOtel'
     ProjectUri = 'https://github.com/ShaydeNofziger/PoshOtel'
     LicenseUri = 'https://github.com/ShaydeNofziger/PoshOtel/blob/main/LICENSE'
-    Tags = @('PSEdition_Desktop')
+    Tags = @('PSEdition_Desktop', 'PSEdition_Core', 'Windows')
     CmdletsToExport = @()
     VariablesToExport = @()
     AliasesToExport = @()
     FileList = $RequiredFiles
-    PowerShellVersion = '5.1'
-    CompatiblePSEditions = @('Desktop')
+    CompatiblePSEditions = @('Desktop', 'Core')
 }
 
 Write-Verbose -Message 'Creating module manifest...'

--- a/src/packages.config
+++ b/src/packages.config
@@ -7,4 +7,5 @@
   <package id="Google.Protobuf" version="3.15.5.0" targetFramework="netstandard2.0" />
   <package id="Grpc.Core" version="2.43.0" targetFramework="netstandard2.0" />
   <package id="Grpc.Core.Api" version="2.43.0" targetFramework="netstandard2.0" />
+  <package id="Microsoft.Extensions.Logging.Abstractions" version="6.0.0" targetFramework="netstandard2.0" />
 </packages>


### PR DESCRIPTION
closes #6 

Add missing package and update support to include powershell core on Windows platform.
