### PR TITLE
Add support for exporting OpenTelemetry data to AzMonitor / AppInsights

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,10 +21,15 @@ Here's a very basic trace in Honeycomb:
 Import-Module .\bin\PoshOtel.psd1
 
 # These need to be set prior to calling the Initialize cmdlet
+
+    # For export to a generic OTLP endpoint
     $env:OTEL_EXPORTER_OTLP_ENDPOINT = 'https://api.honeycomb.io:443'
     $env:OTEL_EXPORTER_OTLP_HEADERS = 'x-honeycomb-team=<<API_KEY>>,x-honeycomb-dataset=<<DATASET>>'
     $env:OTEL_EXPORTER_OTLP_TIMEOUT = '600000'
     $env:OTEL_EXPORTER_OTLP_PROTOCOL = 'grpc'
+
+    # For export to an Azure Monitor / Application Insights endpoint
+    $env:OTEL_EXPORTER_AZUREMONITOR_CONNECTIONSTRING = '<<CONNECTION_STRING>>'
     
 
 Initialize-PoshOtel -ServiceName 'TestConsumer' -ServiceVersion '0.0.1'

--- a/src/packages.config
+++ b/src/packages.config
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="System.Text.Json" version="4.6.0" targetFramework="netstandard2.0" />
+  <package id="System.Text.Encodings.Web" version="4.6.0" targetFramework="netstandard2.0" />
   <package id="OpenTelemetry" version="1.2.0-rc2" targetFramework="netstandard2.0" />
   <package id="OpenTelemetry.Api" version="1.2.0-rc2" targetFramework="netstandard2.0" />
   <package id="OpenTelemetry.Exporter.Console" version="1.2.0-rc2" targetFramework="netstandard2.0" />
@@ -8,4 +10,6 @@
   <package id="Grpc.Core" version="2.43.0" targetFramework="netstandard2.0" />
   <package id="Grpc.Core.Api" version="2.43.0" targetFramework="netstandard2.0" />
   <package id="Microsoft.Extensions.Logging.Abstractions" version="6.0.0" targetFramework="netstandard2.0" />
+  <package id="Azure.Monitor.OpenTelemetry.Exporter" version="1.0.0-beta.3" targetFramework="netstandard2.0" />
+  <package id="Azure.Core" version="1.20.0" targetFramework="netstandard2.0" />
 </packages>

--- a/test/TestConsumer.ps1
+++ b/test/TestConsumer.ps1
@@ -10,7 +10,7 @@ if ($null -eq $Global:TestConsumerInitialized) {
     $Global:TestConsumerInitialized = $false
 }
 if (-not ($Global:TestConsumerInitialized)) {
-    Initialize-PoshOtel -ServiceName 'TestConsumer' -ServiceVersion '0.0.1'
+    Initialize-PoshOtel -ServiceName 'TestConsumer' -ServiceVersion '0.0.1' -AddAzureMonitorTraceExporter
     $Global:TestConsumerInitialized = $true
 }
 


### PR DESCRIPTION
Add support for exporting via the AzureMonitorTraceExporter to send data to Application Insights.